### PR TITLE
Use unicode stream to escape JS strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Vorple
 - Modified the Wikipedia script in The Sum of Human Knowledge example to make
   use of Wikipedia's new extracts feature, which returns a clean summary of the
   article (inform7 #14)
+- Fixed Unicode escaping for JS strings (#22)
 
 
 


### PR DESCRIPTION
This should fix #22. The `VorpleEscapeLineBreaks` routine now uses a Unicode stream to handle strings that should be escaped for JS evaluation.

Based on https://github.com/erkyrath/glk-dev/blob/dd03473182ae298c705738e1996869322a3d6ad1/unittests/memstreamtest.inf#L209